### PR TITLE
[bt#18235] fix watermark for QR bills (and ISR)

### DIFF
--- a/report_qweb_pdf_watermark/models/ir_actions_report.py
+++ b/report_qweb_pdf_watermark/models/ir_actions_report.py
@@ -84,8 +84,8 @@ class IrActionsReport(models.Model):
             watermark_page = pdf.addBlankPage(
                 page.mediaBox.getWidth(), page.mediaBox.getHeight()
             )
-            watermark_page.mergePage(pdf_watermark.getPage(0))
             watermark_page.mergePage(page)
+            watermark_page.mergePage(pdf_watermark.getPage(0))
 
         pdf_content = BytesIO()
         pdf.write(pdf_content)


### PR DESCRIPTION
Watermark was previously drawn below the rectangleof the QR bill or ISR bill strip and could not beseen by the customer.

This switches the merges so that first the content is added to the page and then the watermark to make sure that the watermark is on the top.

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.bt-group.com/web#view_type=form&model=helpdesk.ticket&id=18235">[bt#18235] [ht-3587] Einführung QR-Rechnungen / - Belege (#3587)</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>report_qweb_pdf_watermark</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->