### PR TITLE
Revert "[bt#22264] Fix Crash in Report Controller"

### DIFF
--- a/report_xlsx/controllers/main.py
+++ b/report_xlsx/controllers/main.py
@@ -52,7 +52,6 @@ class ReportController(report.ReportController):
     def report_download(self, data, context=None):
         requestcontent = json.loads(data)
         url, report_type = requestcontent[0], requestcontent[1]
-        reportname = url
         try:
             if report_type == "xlsx":
                 reportname = url.split("/report/xlsx/")[1].split("?")[0]


### PR DESCRIPTION
Reverts brain-tec/reporting-engine#483

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://braintec.com/web#view_type=form&model=helpdesk.ticket&id=22264">[bt#22264] Finanzbericht kann sporadisch nicht erstellt werden</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>report_xlsx</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->