### PR TITLE
[t140653] Avoiding ERROR in log with tests of report_qweb_pdf_watermark

### DIFF
--- a/report_qweb_pdf_watermark/tests/test_report_qweb_pdf_watermark.py
+++ b/report_qweb_pdf_watermark/tests/test_report_qweb_pdf_watermark.py
@@ -51,7 +51,10 @@ class TestReportQwebPdfWatermark(HttpCase):
         # test 0
         numpages = 0
         # pdf_has_usable_pages(self, pdf_watermark)
-        self.assertFalse(self.env["ir.actions.report"].pdf_has_usable_pages(numpages))
+        with self.assertLogs(level="ERROR"):
+            self.assertFalse(
+                self.env["ir.actions.report"].pdf_has_usable_pages(numpages)
+            )
         # test 1
         numpages = 1
         self.assertTrue(self.env["ir.actions.report"].pdf_has_usable_pages(numpages))


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://braintec.com/web#view_type=form&model=project.task&id=140653">[t140653] [OCA] Misc OCA Modules</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>report_qweb_pdf_watermark</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->