### PR TITLE
[t154506][18.0][MIG] report_qweb_element_page_visibility: Migration to 18.0

### DIFF
--- a/report_qweb_element_page_visibility/views/layouts.xml
+++ b/report_qweb_element_page_visibility/views/layouts.xml
@@ -33,16 +33,16 @@
 
                     var operations = {
                         'not-first-page': function (elt) {
-                            elt.style.visibility = (vars.sitepage == vars.frompage) ? "hidden" : "visible";
+                            elt.style.display = (vars.sitepage === vars.frompage) ? "none" : "inherit";
                         },
                         'not-last-page': function (elt) {
-                            elt.style.visibility = (vars.sitepage == vars.sitepages) ? "hidden" : "visible";
+                            elt.style.display = (vars.sitepage === vars.sitepages) ? "none" : "inherit";
                         },
                         'first-page': function (elt) {
-                            elt.style.visibility = (vars.sitepage == vars.frompage) ? "visible" : "hidden";
+                             elt.style.display = (vars.sitepage === vars.frompage) ? "inherit" : "none";
                         },
                         'last-page': function (elt) {
-                            elt.style.visibility = (vars.sitepage == vars.sitepages) ? "visible" : "hidden";
+                            elt.style.display = (vars.sitepage === vars.sitepages) ? "inherit" : "none";
                         },
                         'single-page': function (elt) {
                             elt.style.display = (vars.sitepages === 1) ? "inherit" : "none";


### PR DESCRIPTION
…sibility

the visibility attribute with the hidden option hides the element but don't free the space.

A common use case is to have a specific header for the first page and another for the other pages. With visibility: hidden the second header cannot take the first one place and will keep a huge margin. One solution is to use the display:none instead.

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://braintec.com/web#view_type=form&model=project.task&id=154506">[t154506] Migration 18 - Report Qweb Element Page Visibility</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>report_qweb_element_page_visibility</td><td>.xml</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->